### PR TITLE
Simple thin-edge client that reads Raspberry Pi Sense HAT sensors

### DIFF
--- a/sense-hat/README.md
+++ b/sense-hat/README.md
@@ -1,0 +1,24 @@
+# thin-edge.io Raspberry Pi Sense HAT Demo
+
+## Requirements
+
+- Raspberry Pi 2/3 (RaspberryPi 4 should work as well but not tested)
+- Raspberry Pi Sense HAT (https://www.raspberrypi.org/products/sense-hat/)
+
+## Installation
+
+1. Setup your Raspberry Pi with Raspberry Pi OS (other OS should also work but it is not always easy to get the Sense HAT working)
+2. Make sure `sudo apt-get install sense-hat` is installed (it should be there by default in Raspberry Pi OS)
+3. Install and connect the thin-edge (https://github.com/thin-edge/thin-edge.io/blob/main/docs/src/howto-guides/002_installation.md)
+4. Clone this repository
+5. On the level of setup.py run `sudo python setup.py install`
+
+## Usage
+
+After installation you can start the demo by running `thin-edge-sense-hat`. Optionally you can pass the sending interval and turn of the LEDs if you want to. `thin-edge-sense-hat --interval 5 --image False`.
+The demo is also registered into systemctl and you can run it from there as a service `systemctl start thin-edge-sense-hat`.
+
+## Troubleshooting
+
+### I get a permission denied
+If you get an error like `IOError: [Errno 13] Permission denied: '/dev/fb1'` right at the beginning your user cannot access the sensors. You can simply run the demo as sudo or give your user the permissions to be able to read those interfaces.

--- a/sense-hat/register-service.sh
+++ b/sense-hat/register-service.sh
@@ -1,0 +1,5 @@
+cp -f "thin-edge-sense-hat.service" /lib/systemd/system
+chown root:root /lib/systemd/system/thin-edge-sense-hat.service
+
+systemctl daemon-reload
+systemctl enable thin-edge-sense-hat.service

--- a/sense-hat/setup.py
+++ b/sense-hat/setup.py
@@ -1,0 +1,34 @@
+from setuptools.command.install import install
+from setuptools import setup
+import os
+from subprocess import check_call
+
+
+class ServiceInstaller(install):
+
+    def run(self):
+        install.run(self)
+        path = os.getcwd()
+        check_call(('sh ' + path + '/register-service.sh').split())
+
+setup(
+    name='thin-edge-sense-hat',
+    author='Tobias Sommer',
+    version='0.0.1',
+    description='Reading out the sensors of the RaspberryPi SenseHat and sending the data to thin-edge',
+    install_requires=[
+        'paho-mqtt',
+        'sense-hat'
+    ],
+    packages=[
+        'thin_edge_sense_hat', 
+    ],
+    entry_points = {
+        'console_scripts': [
+            'thin-edge-sense-hat = thin_edge_sense_hat.main:start'
+        ]
+    },
+    cmdclass = {
+        'install': ServiceInstaller
+    }
+)

--- a/sense-hat/thin-edge-sense-hat.service
+++ b/sense-hat/thin-edge-sense-hat.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=thin-edge.io Sense HAT
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/thin-edge-sense-hat
+Environment=PYTHONUNBUFFERED=1
+Restart=on-failure
+TimeoutSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/sense-hat/thin_edge_sense_hat/__init__.py
+++ b/sense-hat/thin_edge_sense_hat/__init__.py
@@ -1,0 +1,1 @@
+from .thin_edge_client import SenseHatThinEdgeClient

--- a/sense-hat/thin_edge_sense_hat/main.py
+++ b/sense-hat/thin_edge_sense_hat/main.py
@@ -1,0 +1,25 @@
+import argparse
+import logging
+from .thin_edge_client import SenseHatThinEdgeClient
+
+def start():
+    parser = argparse.ArgumentParser(description='Starting thin-edge.io SenseHat Demo')
+    parser.add_argument('--interval', type=int, default=10, nargs='?', help='the interval the sensors will be read in seconds (default: 10)')
+    parser.add_argument('--logo', type=argparse_bool, default=True, nargs='?', help='whether the logo should be shown while running (default: True)')
+    args = parser.parse_args()
+
+    logging.info('Started with interval: ' + str(args.interval) + ' and image: ' + str(args.logo))
+
+    thinEdgeClient = SenseHatThinEdgeClient(args.interval, args.logo)
+    thinEdgeClient.start()
+
+def argparse_bool(val):
+    if isinstance(val, bool):
+       return val
+    if val.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif val.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean expected.')
+

--- a/sense-hat/thin_edge_sense_hat/thin_edge_client.py
+++ b/sense-hat/thin_edge_sense_hat/thin_edge_client.py
@@ -1,0 +1,121 @@
+import time
+import json
+import logging
+import signal
+import paho.mqtt.client as mqtt
+from sense_hat import SenseHat, ACTION_PRESSED
+
+bg = [11, 159, 233]
+bl = [3, 40, 88]
+ye = [255, 228, 0]
+
+image = [
+    bg, bl, bg, bg, bg, bg, bg, ye,
+    bl, bl, bl, bg, bg, bg, ye, bg,
+    bg, bl, bg, bg, bg, ye, bg, bg,
+    bg, bl, bg, bg, ye, bg, bl, bg,
+    bg, bl, bg, ye, bg, bl, bg, bl,
+    bg, bg, ye, bg, bg, bl, bl, bl,
+    bg, ye, bg, bg, bg, bl, bg, bg,
+    ye, bg, bg, bg, bg, bg, bl, bl
+]
+
+class SenseHatThinEdgeClient():
+
+    def __init__(self, interval = 10, showImage = True):
+        signal.signal(signal.SIGTERM, self.stop)
+        self.sense = SenseHat()
+        self.client = mqtt.Client()
+        self.running = True
+        self.interval = interval
+        self.showImage = showImage
+
+    def joystick_up(self, event):
+        if event.action == ACTION_PRESSED:
+            move = {
+                'move': 1
+            }
+            self.client.publish('tedge/measurements', json.dumps(move))
+    
+    def joystick_down(self, event):
+        if event.action == ACTION_PRESSED:
+            move = {
+                'move': 2
+            }
+            self.client.publish('tedge/measurements', json.dumps(move))
+
+    def joystick_left(self, event):
+        if event.action == ACTION_PRESSED:
+            move = {
+                'move': 3
+            }
+            self.client.publish('tedge/measurements', json.dumps(move))
+
+    def joystick_right(self, event):
+        if event.action == ACTION_PRESSED:
+            move = {
+                'move': 4
+            }
+            self.client.publish('tedge/measurements', json.dumps(move))
+
+    def joystick_middle(self, event):
+        global client
+        if event.action == ACTION_PRESSED:
+            move = {
+                'move': 5
+            }
+            self.client.publish('tedge/measurements', json.dumps(move))
+
+    def stop(self, signum, frame):
+        self.running = False
+
+    def start(self):
+        try:
+            logging.info('Start thin-edge-sense-hat...')
+            self.client.connect("127.0.0.1", 1883, 60)
+            self.client.loop_start()
+          
+            self.sense.stick.direction_up = self.joystick_up
+            self.sense.stick.direction_down = self.joystick_down
+            self.sense.stick.direction_left = self.joystick_left
+            self.sense.stick.direction_right = self.joystick_right
+            self.sense.stick.direction_middle = self.joystick_middle
+
+            self.sense.show_message("thin-edge.io sense-hat", text_colour=bl)
+            time.sleep(10)
+
+            if self.showImage:
+                self.sense.low_light = True
+                self.sense.set_pixels(image)
+
+            while self.running:
+                time.sleep(self.interval)
+                compass = self.sense.compass_raw
+                gyro = self.sense.gyro_raw
+                accelerometer = self.sense.accelerometer_raw
+                measurements = {
+                    'temperature': self.sense.temperature,
+                    'humidity': self.sense.humidity,
+                    'pressure': self.sense.pressure,
+                    'compass': {
+                        'x': compass['x'],
+                        'y': compass['y'],
+                        'z': compass['z']
+                    } ,
+                    'gyro': {
+                        'x': gyro['x'],
+                        'y': gyro['y'],
+                        'z': gyro['z']            
+                    },
+                    'accelerometer': {
+                        'x': accelerometer['x'],
+                        'y': accelerometer['y'],
+                        'z': accelerometer['z']            
+                    }
+                }
+                self.client.publish('tedge/measurements', json.dumps(measurements))
+        except Exception as e:
+            logging.error(str(e))
+        finally:
+            logging.info('Stopping thin-edge-sense-hat...')
+            self.sense.clear() 


### PR DESCRIPTION
Created a small python client which reads out the sensors of the Raspberry Pi Sense HAT and transforms them to thin-edge.io measurements on the local broker.

The installation of the python package also creates a systemctl entry so that it can easy be run in the background and on startup.