### PR TITLE
Make engine_deploy optional for StreamingAnalytics/LimitedBandwidth sample

### DIFF
--- a/StreamingAnalytics/LimitedBandwidth/README.md
+++ b/StreamingAnalytics/LimitedBandwidth/README.md
@@ -42,9 +42,10 @@ sensors/vibration: {"vibration":0.12098}
 cloud service you should see the measurement(s) appear there.
 Otherwise, run `cat <path to correlator log>` to print out the contents of
 the correlator log file. The actual path to the correlator log file is
-determined by the project's configuration and any `--logfile` argument passed
+determined by the project's configuration or the `--logfile` argument passed
 to the correlator in the [apama service script](../src/service/apama). In the
 correlator's output you should see log messages indicating that the combined
 measurement has been sent to `tedge/measurements`.
-> Note: The `--logfile` argument overrides any setting in the project's 
-configuration files.
+> _Caution:_ The correlator will fail to start if you specify the name of the
+> logfile in both the project configuration and the `--logfile` argument to
+> the correlator.

--- a/StreamingAnalytics/LimitedBandwidth/README.md
+++ b/StreamingAnalytics/LimitedBandwidth/README.md
@@ -13,16 +13,21 @@ Follow the setup and configuration instructions in the [README](../README.md)
 file in the parent directory before running this sample.
 
 ## How to run the sample
-1. From an Apama command prompt in your full Apama installation, run
-`engine_deploy --outputDeployDir deployed LimitedBandwidth` from the 
-parent directory ([StreamingAnalytics](../)).
-2. Copy the contents of the `deployed` directory that was created by the
-previous step to the `/etc/tedge/apama/project` directory on the thin-edge
-device.
-3. On the thin-edge device, restart the service with `sudo service apama
+
+> Note: If you intend to modify or extend this sample it is recommended that
+> you delete the provided [config.yaml](config.yaml) file and use
+> `engine_deploy` from a full Apama installation to build a deployable version
+> of your project which you then copy to the thin-edge device. This is because
+> building out this sample is likely to break the configuration in
+> [config.yaml](config.yaml) and using `engine_deploy` will work out the
+> correct initialization order when creating a deployable project.
+
+1. Copy the contents of this directory ([LimitedBandwidth](./)) to the
+`/etc/tedge/apama/project` directory on the thin-edge device.
+2. On the thin-edge device, restart the service with `sudo service apama
 restart`. This will restart the correlator and run the project that was copied
 in the previous step.
-4. Exercise the sample by publishing events to sensors/temperature,
+3. Exercise the sample by publishing events to sensors/temperature,
 sensors/pressure and sensors/vibration topics via `tedge mqtt pub`, script or
 other MQTT utility.
 
@@ -33,14 +38,13 @@ sensors/pressure: {"pressure":68.265}
 sensors/vibration: {"vibration":0.12098}
 ```
 
-5. If you have configured thin-edge to connect to Cumulocity IoT or another
+4. If you have configured thin-edge to connect to Cumulocity IoT or another
 cloud service you should see the measurement(s) appear there.
 Otherwise, run `cat <path to correlator log>` to print out the contents of
 the correlator log file. The actual path to the correlator log file is
 determined by the project's configuration and any `--logfile` argument passed
-to the correlator in the [apama service script](../src/service/apama).
+to the correlator in the [apama service script](../src/service/apama). In the
+correlator's output you should see log messages indicating that the combined
+measurement has been sent to `tedge/measurements`.
 > Note: The `--logfile` argument overrides any setting in the project's 
 configuration files.
-
-In the correlator's output you should see log messages indicating that the
-combined measurement has been sent to `tedge/measurements`.

--- a/StreamingAnalytics/LimitedBandwidth/config.yaml
+++ b/StreamingAnalytics/LimitedBandwidth/config.yaml
@@ -1,0 +1,15 @@
+# Root configuration file which inherits other config files
+# and contains the initialization list.
+
+includes:
+   - ${APAMA_HOME}/connectivity/bundles/standard-codecs.yaml
+   - ${PARENT_DIR}/config/connectivity/MQTT/MQTT.properties
+   - ${PARENT_DIR}/config/connectivity/MQTT/MQTT.yaml
+
+correlator:
+    initialization:
+        list:
+            - ${APAMA_HOME}/monitors/ConnectivityPluginsControl.mon
+            - ${APAMA_HOME}/monitors/ConnectivityPlugins.mon
+            - ${PARENT_DIR}/eventdefinitions/EventDefs.mon
+            - ${PARENT_DIR}/monitors/ThinEdgeIoExample.mon

--- a/StreamingAnalytics/README.md
+++ b/StreamingAnalytics/README.md
@@ -1,14 +1,27 @@
 # Prerequisites
 
 - A Raspberry Pi (minimum version 3) running Raspberry Pi OS 32bit. 
-- Thin-edge.io installed to the Raspberry Pi, which can be done by following the instructions [here](https://github.com/thin-edge/thin-edge.io/blob/main/docs/src/howto-guides/002_installation.md).
-- A full installation of [Apama Community Edition](https://apamacommunity.com/downloads/) including Software AG Designer on a laptop or PC.
-- _Recommended_: Thin-edge configured with connection to Cumulocity or Azure using the instructions [here](https://github.com/thin-edge/thin-edge.io/blob/main/docs/src/howto-guides/004_connect.md).
+- thin-edge.io installed to the Raspberry Pi, which can be done by following the instructions [here](https://github.com/thin-edge/thin-edge.io/blob/main/docs/src/howto-guides/002_installation.md).
+- _Recommended:_ thin-edge configured with connection to Cumulocity or Azure using the instructions
+[here](https://github.com/thin-edge/thin-edge.io/blob/main/docs/src/howto-guides/004_connect.md).
 
+## Optional
+
+These are not essential to be able to run the examples here, but are
+recommended if you want to modify or extend the examples or implement a real
+solution with Apama and thin-edge.
+
+- A full installation of [Apama Community Edition](https://apamacommunity.com/downloads/)
+including Software AG Designer on a laptop or PC.
+- Docker and the apama-builder and apama-correlator images. See the links below
+for more details.
+	- https://tech.forums.softwareag.com/t/apama-builder-for-docker/237796
+	- https://hub.docker.com/_/softwareag-apama-builder
+	- https://hub.docker.com/_/apama-correlator
 
 # Setup and Configuration
 ## Installing Apama Community Core to the Raspberry Pi
-Download the Apama Community Core zip for Arm to the Raspberry Pi.  The latest version is available from the [Apama Community Edition Downloads page](https://www.apamacommunity.com/downloads/) .
+Download the Apama Community Core zip for Arm to the Raspberry Pi. The latest version is available from the [Apama Community Edition Downloads page](https://www.apamacommunity.com/downloads/).
 
 Untar the archive to /opt/softwareag:
 

--- a/StreamingAnalytics/README.md
+++ b/StreamingAnalytics/README.md
@@ -7,9 +7,10 @@
 
 ## Optional
 
-These are not essential to be able to run the examples here, but are
-recommended if you want to modify or extend the examples or implement a real
-solution with Apama and thin-edge.
+These are not essential to be able to run the examples provided. If you want to
+modify or extend the examples or implement a real solution with Apama and
+thin-edge we recommend you follow the guidance on creating, configuring and
+deploying a project contained within this document.
 
 - A full installation of [Apama Community Edition](https://apamacommunity.com/downloads/)
 including Software AG Designer on a laptop or PC.


### PR DESCRIPTION
## Proposed changes

I've added a configuration file and updated the README to make engine_deploy optional for using this example. Added a note to recommend using it (and deleting config.yaml) if modifying/extending the example so that any new files are in the initialization list and the order is correct.

Also modified the StreamingAnalytics/README file to make the full install optional. Added links to Apama docker images as well.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New example (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s) _Not required - I am a SAG employee_
- [x] I have added necessary documentation (if appropriate)

## Further comments

None