### PR TITLE
PAM-33150: Create resource monitoring sample

### DIFF
--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/.dependencies
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/.dependencies
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<apama-project>
+	<dependency>
+		<dependencyentry path="" kind="src"/>
+	</dependency>
+	<catalogs>
+	</catalogs>
+	<bundles>
+		<bundle file="MQTTConnectivity.bnd" origin-path="" origin="CONNECTIVITY_CATALOG">
+			<config-files>
+			</config-files>
+			<bundle-instance-files>
+				<file name="../bundles/MQTTConnectivity/@INSTANCE_NAME@.properties" timestamp="1630667311171"/>
+				<file name="../bundles/MQTTConnectivity/@INSTANCE_NAME@.yaml" timestamp="1630667311172"/>
+			</bundle-instance-files>
+			<static-files>
+			</static-files>
+			<dashboard-files>
+			</dashboard-files>
+			<evt-files>
+			</evt-files>
+		</bundle>
+		<bundle file="JSONPlugin.bnd" origin-path="" origin="PRODUCT_CATALOG">
+			<instance name=""/>
+			<config-files>
+			</config-files>
+			<bundle-instance-files>
+			</bundle-instance-files>
+			<static-files>
+			</static-files>
+			<dashboard-files>
+			</dashboard-files>
+			<evt-files>
+			</evt-files>
+		</bundle>
+		<bundle file="TimeFormat.bnd" origin-path="" origin="PRODUCT_CATALOG">
+			<instance name=""/>
+			<config-files>
+			</config-files>
+			<bundle-instance-files>
+			</bundle-instance-files>
+			<static-files>
+			</static-files>
+			<dashboard-files>
+			</dashboard-files>
+			<evt-files>
+			</evt-files>
+		</bundle>
+	</bundles>
+</apama-project>

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/.project
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ResourceMonitoring</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>com.apama.text.progressBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>com.apama.text.progressNature</nature>
+	</natures>
+</projectDescription>

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/.settings/org.eclipse.core.resources.prefs
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding//config/connectivity/MQTT/MQTT.yaml=UTF-8

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/config/CorrelatorConfig.yaml
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/config/CorrelatorConfig.yaml
@@ -1,0 +1,19 @@
+###############################################################################
+# $Copyright (c) 2016 Software AG, Darmstadt, Germany and/or Software AG USA Inc., Reston, VA, USA, and/or its subsidiaries and/or its affiliates and/or their licensors.$
+# Use, reproduction, transfer, publication or disclosure is prohibited except as specifically provided for in your License Agreement with Software AG
+###############################################################################
+
+#To set the default log file and level for an EPL package, monitor, or event, specify
+# logging details in the eplLogging section of the YAML configuration file.
+#For example:
+#eplLogging:
+#  com.myCompany.Client:
+#    file: apama/Client.log
+#    level: DEBUG
+#  com.myCompany.Internal: { level: ERROR }
+
+
+#See the information on setting log files and log levels in a YAML configuration file in the documentation for more
+# information about the supported options.
+#To enable use of this file when you launch this project from Designer, edit the project's run/launch configuration,
+#open the correlator, and tick the "Configuration" checkbox next to the textbox that names this .yaml file.

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/config/connectivity/MQTT/.settings
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/config/connectivity/MQTT/.settings
@@ -1,0 +1,1 @@
+bundleLocation=${APAMA_HOME}/connectivity/bundles/MQTTConnectivity.bnd

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/config/connectivity/MQTT/MQTT.properties
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/config/connectivity/MQTT/MQTT.properties
@@ -1,0 +1,36 @@
+# $Copyright (c) 2016,2018 Software AG, Darmstadt, Germany and/or Software AG USA Inc., Reston, VA, USA, and/or its subsidiaries and/or its affiliates and/or their licensors.$
+# Use, reproduction, transfer, publication or disclosure is prohibited except as specifically provided for in your License Agreement with Software AG
+#
+# This file contains the main properties that need configuring to use this connectivity plug-in. 
+#
+# The properties defined here are used to replace ${...} substitution variables in the YAML file(s). 
+# For more advanced transport and codec configuration, see the associated YAML file. 
+# Backslash characters in property values must be escaped (e.g. \\). 
+#
+
+###########################################################################################
+# MQTT connectivity plug-in configuration for sending/receiving events to/from an MQTT
+# broker. Codecs will need to be configured in the corresponding YAML file.
+###########################################################################################
+
+# Use this setting to specify the URL of the broker you want to use for MQTT connectivity.
+MQTT_brokerURL=localhost
+
+# Use these settings to specify credentials for authentication, if required.
+MQTT_username=
+MQTT_password=
+
+# If non-validated server certificates are to be accepted or not
+MQTT_acceptUnrecognizedCertificates=true
+
+# Path to a CA certificate file for verifying the server in PEM format
+MQTT_certificateAuthorityFile=
+
+# Path to a certificate file for verifying the client in PEM format
+MQTT_certificateFile=
+
+# Path to the client's private key in PEM format, if not already included in the certificate file
+MQTT_privateKeyFile=
+
+# Used to decrypt the client's private key, if encrypted
+MQTT_certificatePassword=

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/config/connectivity/MQTT/MQTT.properties
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/config/connectivity/MQTT/MQTT.properties
@@ -14,7 +14,7 @@
 ###########################################################################################
 
 # Use this setting to specify the URL of the broker you want to use for MQTT connectivity.
-MQTT_brokerURL=localhost
+MQTT_brokerURL=localhost:1883
 
 # Use these settings to specify credentials for authentication, if required.
 MQTT_username=

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/config/connectivity/MQTT/MQTT.yaml
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/config/connectivity/MQTT/MQTT.yaml
@@ -1,0 +1,76 @@
+# Copyright (c) 2016,2018 Software AG, Darmstadt, Germany and/or Software AG USA Inc., Reston, VA, USA, and/or its subsidiaries and/or its affiliates and/or their licensors.
+# Use, reproduction, transfer, publication or disclosure is prohibited except as specifically provided for in your License Agreement with Software AG
+# This is a YAML configuration file. See the associated .properties file for an 
+# easy way to change the most commonly needed configuration settings. 
+#
+# When editing YAML files, be sure to use spaces (not tabs) for indentation. 
+# List entries are denoted by a line beginning with hyphen and space ("- ").
+# Map key and value pairs are separated by a colon and new line or space ("key: value").
+# Empty strings and those that need escaping should be surrounded by double-quotes ("...").
+# Apama replaces ${prop} substitution variables with the configured value of the 
+# specified property, taken from the command line or from .properties files. 
+#
+
+###########################################################################################
+# MQTT connectivity configuration for sending/receiving events to/from an MQTT broker 
+#
+# Most user-accessible configuration is available and documented in the properties file,
+# except for the codecs used to do the EPL <-> binary message translation.
+###########################################################################################
+
+connectivityPlugins:
+  MQTTTransport:
+    libraryName: connectivity-mqtt
+    class: MQTTTransport
+  classifierCodec:
+    libraryName: ClassifierCodec
+    class: ClassifierCodec
+  jsonCodec:
+    libraryName: connectivity-json-codec
+    class: JSONCodec
+  stringCodec:
+    libraryName: connectivity-string-codec
+    class: StringCodec
+
+# The chain manager, responsible for the connection to MQTT
+dynamicChainManagers:
+  MQTTManager:
+    transport: MQTTTransport
+    managerConfig:
+      # WARNING: If you are using multiple MQTT bundles, make sure that each chain manager
+      # is configured with a distinct prefix to avoid unexpected behaviour
+      channelPrefix: "mqtt:"
+      brokerURL: ${MQTT_brokerURL}
+      certificateAuthorityFile: ${MQTT_certificateAuthorityFile}
+      acceptUnrecognizedCertificates: ${MQTT_acceptUnrecognizedCertificates}
+      authentication:
+        username: ${MQTT_username}
+        password: ${MQTT_password}
+        certificateFile: ${MQTT_certificateFile}
+        certificatePassword: ${MQTT_certificatePassword}
+        privateKeyFile: ${MQTT_privateKeyFile}
+
+dynamicChains:
+  # This is a sample chain definition showing how to turn a JSON message from MQTT broker to EPL events
+  MQTTChain:
+    - apama.eventMap:
+        suppressLoopback: true
+
+    #- diagnosticCodec:
+
+    - classifierCodec:
+        rules:
+          - Cpu-inst:
+            - metadata.mqtt.topic: collectd/thin-edge/cpu/percent-active
+          - Mem-inst:
+            - metadata.mqtt.topic: collectd/thin-edge/mem/percent-used
+                
+    # Codec that logs message contents during testing/debugging - should be commented out in production
+    #- diagnosticCodec:
+    
+    - jsonCodec:
+    - stringCodec:
+        nullTerminated: false
+    
+    - MQTTTransport
+

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/config/connectivity/MQTT/MQTT.yaml
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/config/connectivity/MQTT/MQTT.yaml
@@ -31,6 +31,9 @@ connectivityPlugins:
   stringCodec:
     libraryName: connectivity-string-codec
     class: StringCodec
+  mapperCodec:
+   libraryName: MapperCodec
+   class: MapperCodec
 
 # The chain manager, responsible for the connection to MQTT
 dynamicChainManagers:
@@ -55,22 +58,30 @@ dynamicChains:
   MQTTChain:
     - apama.eventMap:
         suppressLoopback: true
-
-    #- diagnosticCodec:
-
+    - mapperCodec:
+        allowMissing: false
+        RawCpuMeasurement:
+            towardsHost:
+                mapFrom:
+                    - payload.cpuMeasurement: payload
+        RawMemMeasurement:
+            towardsHost:
+                mapFrom:
+                    - payload.memMeasurement: payload
+        ResourceUsageReport:
+            towardsTransport:
+                defaultValue:
+                    - metadata.contentType: "application/json"
+                mapFrom:
+                    - payload.cpu.percent-active: payload.cpuPercentActive
+                    - payload.memory.percent-used: payload.memPercentUsed
     - classifierCodec:
         rules:
-          - Cpu-inst:
+          - RawCpuMeasurement:
             - metadata.mqtt.topic: collectd/thin-edge/cpu/percent-active
-          - Mem-inst:
+          - RawMemMeasurement:
             - metadata.mqtt.topic: collectd/thin-edge/mem/percent-used
-                
-    # Codec that logs message contents during testing/debugging - should be commented out in production
-    #- diagnosticCodec:
-    
     - jsonCodec:
+        filterOnContentType: true
     - stringCodec:
-        nullTerminated: false
-    
     - MQTTTransport
-

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/eventdefinitions/ResourceMonitoringEventDefinitions.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/eventdefinitions/ResourceMonitoringEventDefinitions.mon
@@ -1,4 +1,3 @@
-
 event RawCpuMeasurement {
 	string cpuMeasurement;
 }
@@ -13,4 +12,10 @@ event CpuMeasurement {
 
 event MemMeasurement {
 	float percentUsed;
+}
+
+event ResourceUsageReport {
+	string time;
+	float cpuPercentActive;
+	float memPercentUsed;
 }

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/eventdefinitions/ResourceMonitoringEventDefinitions.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/eventdefinitions/ResourceMonitoringEventDefinitions.mon
@@ -1,0 +1,16 @@
+
+event RawCpuMeasurement {
+	string cpuMeasurement;
+}
+
+event RawMemMeasurement {
+	string memMeasurement;
+}
+
+event CpuMeasurement {
+	float cpuMeasurement;
+}
+
+event MemMeasurement {
+	float memMeasurement;
+}

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/eventdefinitions/ResourceMonitoringEventDefinitions.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/eventdefinitions/ResourceMonitoringEventDefinitions.mon
@@ -8,9 +8,9 @@ event RawMemMeasurement {
 }
 
 event CpuMeasurement {
-	float cpuMeasurement;
+	float percentActive;
 }
 
 event MemMeasurement {
-	float memMeasurement;
+	float percentUsed;
 }

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
@@ -1,10 +1,14 @@
 using com.apama.aggregates.mean;
 
-/** This monitor is responsible for ...  */
+/**
+ *  This monitor is responsible for process and aggregate the cpu and memory usage measurments received over a
+ *  certain period of time. If reports the average values to the cloud for cpu/memory usage in an interval of 
+ *  five minutes if the average breaches THRESHOLD values, otherwise it does an hourly paper report.
+ */
 monitor DeviceResourceMonitor {
 
 	constant string MQTT_SEND_CHANNEL := "out";
-	constant string MQTT_SUBSCRIBE_CHANNEL := "mqtt:cpu/percent-active";
+	constant string PROCESSED_MEASUREMENTS_CHANNEL := "PROCESSED_MEASUREMENTS_CHANNEL";
 
 	constant float ONE_HOUR_INTERVAL := 120.0;
 	constant float FIVE_MINS_INTERVAL := 10.0;
@@ -24,44 +28,40 @@ monitor DeviceResourceMonitor {
 
 	action onload() {
 		log "Loaded monitor DeviceResourceMonitor" at INFO;
-		monitor.subscribe("PROCESSED_MEASUREMENTS_CHANNEL");
+		monitor.subscribe(PROCESSED_MEASUREMENTS_CHANNEL);
 
-		// schedules the initial reports on load
+		// schedule the initial reports on load
 		nextCpuReportWait := scheduleNextHourlyReport(nextCpuReportWait, paperReportCpuUsage);
 		nextMemReportWait := scheduleNextHourlyReport(nextMemReportWait, paperReportMemoryUsage);
 
 		// stream of cpu measurements
 		stream<CpuMeasurement> cpuMeasurementStream := all CpuMeasurement();
 
-		// reports in FIVE_MINS_INTERVALs if the lastFiveMinAverage of cpu measurements breaches CPU_AVERAGE_THRESHOLD
+		// report lastFiveMinAverage of cpu measurements if it has breached CPU_AVERAGE_THRESHOLD
+		// and we have not reported in the last FIVE_MINS_INTERVAL
 		from cpuMeasurement in cpuMeasurementStream within FIVE_MINS_INTERVAL select mean(cpuMeasurement.cpuMeasurement) as lastFiveMinAverage {
-			// reports the lastFiveMinAverage immediately if it has breached CPU_AVERAGE_THRESHOLD
-			// and we have not reported in the last FIVE_MINS_INTERVAL
 			if (lastFiveMinAverage >= CPU_AVERAGE_THRESHOLD and lastCpuReportTime + FIVE_MINS_INTERVAL <= currentTime) {
 				reportCpuUsage(lastFiveMinAverage);
 			}
 		}
 
-		// maintains an average  in case it is going to be an hourly paper report
+		// maintain an overall average in case it is going to be an hourly paper report
 		from cpuMeasurement in cpuMeasurementStream select cpuMeasurement.cpuMeasurement as measurement {
 			// calculate the cumulative average of the readings received since the last cpu usage report to the cloud
 			cpuPercentCMA := cpuPercentCMA + (measurement - cpuPercentCMA)/(cpuReadings + 1).toFloat();
 			cpuReadings := cpuReadings + 1;
 		}
 
-		// sets up the same for memory usage measurements
+		// set up the same for memory usage measurements
 		stream<MemMeasurement> memMeasurementStream := all MemMeasurement();
 
 		from memMeasurement in memMeasurementStream within FIVE_MINS_INTERVAL select mean(memMeasurement.memMeasurement) as lastFiveMinAverage {
-			//	log "lastFiveMinAverage " + lastFiveMinAverage.toString();
 				if (lastFiveMinAverage >= MEM_AVERAGE_THRESHOLD and lastMemReportTime + FIVE_MINS_INTERVAL <= currentTime) {
-					// report the lastFiveMinAverage immediately if we have not reported in the last FIVE_MINS_INTERVAL
 					reportMemoryUsage(lastFiveMinAverage);
 				}
 			}
 
 		from memMeasurement in memMeasurementStream select memMeasurement.memMeasurement as measurement {
-		//	log memPercentCMA.toString() + " measurement " + measurement.toString();
 			memPercentCMA := memPercentCMA + (measurement - memPercentCMA)/(memReadings + 1).toFloat();
 			memReadings := memReadings + 1;
 		}

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
@@ -1,80 +1,112 @@
-event StatusUpdate {
-	float readTime;
-	float cpuPercent;
-	float memPercent;
-	
-}
-
-event StatusReport {
-	float reportTime;
-	float cpuPercent;
-	float memPercent;
-	float monitoringDuration;
-}
+using com.apama.aggregates.mean;
 
 /** This monitor is responsible for ...  */
 monitor DeviceResourceMonitor {
-	
+
 	constant string MQTT_SEND_CHANNEL := "out";
-	constant string MQTT_SUBSCRIBE_CHANNEL := "in";
+	constant string MQTT_SUBSCRIBE_CHANNEL := "mqtt:cpu/percent-active";
 
 	constant float ONE_HOUR_INTERVAL := 120.0;
 	constant float FIVE_MINS_INTERVAL := 10.0;
-	
+
 	constant float CPU_AVERAGE_THRESHOLD := 70.0;
 	constant float MEM_AVERAGE_THRESHOLD := 70.0;
-	
-	integer readings;
-	float cpuPercentCMA;
-	float memPercentCMA;
-	float lastStatusReportTime;
-	
-	listener nextStatusReportWait;
-	float currentMonitoringFor;
-	
-	action onload() {
-		log "Loaded monitor DeviceResourceMonitor" at INFO;		
 
-		monitor.subscribe(MQTT_SUBSCRIBE_CHANNEL);
-	
-		resetVariables();
-		scheduleNextStatusReport(ONE_HOUR_INTERVAL);
-		
-		on all StatusUpdate() as statusUpdate {
-			cpuPercentCMA := cpuPercentCMA + (statusUpdate.cpuPercent - cpuPercentCMA)/(readings+1).toFloat();
-			memPercentCMA := memPercentCMA + (statusUpdate.memPercent - memPercentCMA)/(readings+1).toFloat();
-			
-			readings := readings + 1;
-			//log "Status Update " + statusUpdate.toString();
-			//log cpuPercentCMA.toString() + " ====,===== " + memPercentCMA.toString() + " +===+ " + readings.toString();
-			
-			// No need for extra checks if we are going to report numbers after FIVE_MINS_INTERVAL
-			if (currentMonitoringFor = FIVE_MINS_INTERVAL) {
-				return;
-			}
-			if (cpuPercentCMA >= CPU_AVERAGE_THRESHOLD or memPercentCMA >= MEM_AVERAGE_THRESHOLD) {
-				scheduleNextStatusReport(FIVE_MINS_INTERVAL);
+	integer cpuReadings := 0;
+	float cpuPercentCMA := 0.0;
+	float lastCpuReportTime := 0.0;
+	listener nextCpuReportWait;
+
+	integer memReadings := 0;
+	float memPercentCMA := 0.0;
+	float lastMemReportTime := 0.0;
+	listener nextMemReportWait;
+
+	action onload() {
+		log "Loaded monitor DeviceResourceMonitor" at INFO;
+		monitor.subscribe("PROCESSED_MEASUREMENTS_CHANNEL");
+
+		// schedules the initial reports on load
+		nextCpuReportWait := scheduleNextHourlyReport(nextCpuReportWait, paperReportCpuUsage);
+		nextMemReportWait := scheduleNextHourlyReport(nextMemReportWait, paperReportMemoryUsage);
+
+		// stream of cpu measurements
+		stream<CpuMeasurement> cpuMeasurementStream := all CpuMeasurement();
+
+		// reports in FIVE_MINS_INTERVALs if the lastFiveMinAverage of cpu measurements breaches CPU_AVERAGE_THRESHOLD
+		from cpuMeasurement in cpuMeasurementStream within FIVE_MINS_INTERVAL select mean(cpuMeasurement.cpuMeasurement) as lastFiveMinAverage {
+			// reports the lastFiveMinAverage immediately if it has breached CPU_AVERAGE_THRESHOLD
+			// and we have not reported in the last FIVE_MINS_INTERVAL
+			if (lastFiveMinAverage >= CPU_AVERAGE_THRESHOLD and lastCpuReportTime + FIVE_MINS_INTERVAL <= currentTime) {
+				reportCpuUsage(lastFiveMinAverage);
 			}
 		}
-	}
-	
-	action scheduleNextStatusReport(float monitoringDuration) {
-		nextStatusReportWait.quit();
-		float waitInterval := lastStatusReportTime + monitoringDuration - currentTime;
-		nextStatusReportWait := on wait(waitInterval) {
-			send StatusReport(currentTime, cpuPercentCMA, memPercentCMA, monitoringDuration) to MQTT_SEND_CHANNEL;
-			resetVariables();
-			
-			// Always schedule the next report to the default ONE_HOUR_INTERVAL
-			scheduleNextStatusReport(ONE_HOUR_INTERVAL);
+
+		// maintains an average  in case it is going to be an hourly paper report
+		from cpuMeasurement in cpuMeasurementStream select cpuMeasurement.cpuMeasurement as measurement {
+			// calculate the cumulative average of the readings received since the last cpu usage report to the cloud
+			cpuPercentCMA := cpuPercentCMA + (measurement - cpuPercentCMA)/(cpuReadings + 1).toFloat();
+			cpuReadings := cpuReadings + 1;
 		}
-		currentMonitoringFor := monitoringDuration;
+
+		// sets up the same for memory usage measurements
+		stream<MemMeasurement> memMeasurementStream := all MemMeasurement();
+
+		from memMeasurement in memMeasurementStream within FIVE_MINS_INTERVAL select mean(memMeasurement.memMeasurement) as lastFiveMinAverage {
+			//	log "lastFiveMinAverage " + lastFiveMinAverage.toString();
+				if (lastFiveMinAverage >= MEM_AVERAGE_THRESHOLD and lastMemReportTime + FIVE_MINS_INTERVAL <= currentTime) {
+					// report the lastFiveMinAverage immediately if we have not reported in the last FIVE_MINS_INTERVAL
+					reportMemoryUsage(lastFiveMinAverage);
+				}
+			}
+
+		from memMeasurement in memMeasurementStream select memMeasurement.memMeasurement as measurement {
+		//	log memPercentCMA.toString() + " measurement " + measurement.toString();
+			memPercentCMA := memPercentCMA + (measurement - memPercentCMA)/(memReadings + 1).toFloat();
+			memReadings := memReadings + 1;
+		}
+
 	}
-	
-	action resetVariables() {
-		readings := 0;
+
+	action reportCpuUsage(float averageCpuUsage) {
+		float reportingTime := currentTime;
+		send RawCpuMeasurement(reportingTime.toString() + ":" + averageCpuUsage.toString()) to MQTT_SEND_CHANNEL;
+
+		// reset the cpu variables
+		cpuReadings := 0;
 		cpuPercentCMA := 0.0;
+		lastCpuReportTime := reportingTime;
+
+		// schedule the next report
+		nextCpuReportWait := scheduleNextHourlyReport(nextCpuReportWait, paperReportCpuUsage);
+	}
+
+	action paperReportCpuUsage() {
+		reportCpuUsage(memPercentCMA);
+	}
+
+	action reportMemoryUsage(float averageMemUsage) {
+		float reportingTime := currentTime;
+		send RawMemMeasurement(reportingTime.toString() + ":" + averageMemUsage.toString()) to MQTT_SEND_CHANNEL;
+
+		// reset the mem variables
+		memReadings := 0;
 		memPercentCMA := 0.0;
-		lastStatusReportTime := currentTime;
+		lastMemReportTime := reportingTime;
+
+		// schedule the next paper report
+		nextMemReportWait := scheduleNextHourlyReport(nextMemReportWait, paperReportMemoryUsage);
+	}
+
+	action paperReportMemoryUsage() {
+		reportMemoryUsage(memPercentCMA);
+	}
+
+	action scheduleNextHourlyReport(listener currentWaitListener, action<> reportUsageAction) returns listener {
+		currentWaitListener.quit();
+		listener newWaitListener := on wait(ONE_HOUR_INTERVAL) {
+			reportUsageAction();
+		}
+		return newWaitListener;
 	}
 }

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
@@ -1,13 +1,80 @@
 event StatusUpdate {
-	string readTime;
+	float readTime;
 	float cpuPercent;
-	float memPercent;	
+	float memPercent;
+	
 }
 
+event StatusReport {
+	float reportTime;
+	float cpuPercent;
+	float memPercent;
+	float monitoringDuration;
+}
 
 /** This monitor is responsible for ...  */
 monitor DeviceResourceMonitor {
+	
+	constant string MQTT_SEND_CHANNEL := "out";
+	constant string MQTT_SUBSCRIBE_CHANNEL := "in";
+
+	constant float ONE_HOUR_INTERVAL := 120.0;
+	constant float FIVE_MINS_INTERVAL := 10.0;
+	
+	constant float CPU_AVERAGE_THRESHOLD := 70.0;
+	constant float MEM_AVERAGE_THRESHOLD := 70.0;
+	
+	integer readings;
+	float cpuPercentCMA;
+	float memPercentCMA;
+	float lastStatusReportTime;
+	
+	listener nextStatusReportWait;
+	float currentMonitoringFor;
+	
 	action onload() {
 		log "Loaded monitor DeviceResourceMonitor" at INFO;		
+
+		monitor.subscribe(MQTT_SUBSCRIBE_CHANNEL);
+	
+		resetVariables();
+		scheduleNextStatusReport(ONE_HOUR_INTERVAL);
+		
+		on all StatusUpdate() as statusUpdate {
+			cpuPercentCMA := cpuPercentCMA + (statusUpdate.cpuPercent - cpuPercentCMA)/(readings+1).toFloat();
+			memPercentCMA := memPercentCMA + (statusUpdate.memPercent - memPercentCMA)/(readings+1).toFloat();
+			
+			readings := readings + 1;
+			//log "Status Update " + statusUpdate.toString();
+			//log cpuPercentCMA.toString() + " ====,===== " + memPercentCMA.toString() + " +===+ " + readings.toString();
+			
+			// No need for extra checks if we are going to report numbers after FIVE_MINS_INTERVAL
+			if (currentMonitoringFor = FIVE_MINS_INTERVAL) {
+				return;
+			}
+			if (cpuPercentCMA >= CPU_AVERAGE_THRESHOLD or memPercentCMA >= MEM_AVERAGE_THRESHOLD) {
+				scheduleNextStatusReport(FIVE_MINS_INTERVAL);
+			}
+		}
+	}
+	
+	action scheduleNextStatusReport(float monitoringDuration) {
+		nextStatusReportWait.quit();
+		float waitInterval := lastStatusReportTime + monitoringDuration - currentTime;
+		nextStatusReportWait := on wait(waitInterval) {
+			send StatusReport(currentTime, cpuPercentCMA, memPercentCMA, monitoringDuration) to MQTT_SEND_CHANNEL;
+			resetVariables();
+			
+			// Always schedule the next report to the default ONE_HOUR_INTERVAL
+			scheduleNextStatusReport(ONE_HOUR_INTERVAL);
+		}
+		currentMonitoringFor := monitoringDuration;
+	}
+	
+	action resetVariables() {
+		readings := 0;
+		cpuPercentCMA := 0.0;
+		memPercentCMA := 0.0;
+		lastStatusReportTime := currentTime;
 	}
 }

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
@@ -1,4 +1,5 @@
 using com.apama.aggregates.count;
+using com.apama.correlator.timeformat.TimeFormat;
 
 /**
  *  This monitor is responsible for processing the cpu and memory usage measurments received over a certain period
@@ -8,7 +9,7 @@ using com.apama.aggregates.count;
  */
 monitor DeviceResourceMonitor {
 
-	constant string MQTT_SEND_CHANNEL := "out";
+	constant string MQTT_SEND_CHANNEL := "mqtt:tedge/measurements";
 	constant string PROCESSED_MEASUREMENTS_CHANNEL := "PROCESSED_MEASUREMENTS_CHANNEL";
 
 	constant float ONE_HOUR_INTERVAL := 3600.0;
@@ -22,21 +23,19 @@ monitor DeviceResourceMonitor {
 
 	integer cpuReadings := 0;
 	float highCpuTimeFraction := 0.0;
-	float lastCpuReportTime := 0.0;
-	listener nextCpuReportWait;
 
 	integer memReadings := 0;
 	float highMemTimeFraction := 0.0;
-	float lastMemReportTime := 0.0;
-	listener nextMemReportWait;
+
+	float lastReportTime := 0.0;
+	listener nextReportTimer;
 
 	action onload() {
 		log "Loaded monitor DeviceResourceMonitor" at INFO;
 		monitor.subscribe(PROCESSED_MEASUREMENTS_CHANNEL);
 
-		// schedule the initial reports on load
-		nextCpuReportWait := scheduleNextHourlyReport(nextCpuReportWait, paperReportCpuUsage);
-		nextMemReportWait := scheduleNextHourlyReport(nextMemReportWait, paperReportMemoryUsage);
+		// schedule the initial report on load
+		scheduleNextHourlyReport();
 
 		// stream of cpu measurements
 		stream<CpuMeasurement> cpuMeasurementStream := all CpuMeasurement();
@@ -48,8 +47,8 @@ monitor DeviceResourceMonitor {
 		// calculate the time percentage for which cpu usage was above CPU_THRESHOLD within FIVE_MINS_INTERVAL
 		// report lastFiveMinHighUsgaePercentage if it has breached CPU_PERCENTILE_THRESHOLD and it has been five mins since last report
 		from highUsageCount in windowHighCpuUsageCounts from totalCount in windowTotalCpuUsageCounts select 100.0 * highUsageCount.toFloat()/totalCount.toFloat() as lastFiveMinHighUsgaePercentage {
-			if (lastFiveMinHighUsgaePercentage >= CPU_PERCENTILE_THRESHOLD and lastCpuReportTime + FIVE_MINS_INTERVAL <= currentTime) {
-				reportCpuUsage(lastFiveMinHighUsgaePercentage);
+			if (lastFiveMinHighUsgaePercentage >= CPU_PERCENTILE_THRESHOLD and lastReportTime + FIVE_MINS_INTERVAL <= currentTime) {
+				sendReport(lastFiveMinHighUsgaePercentage, highMemTimeFraction * 100.0);
 			}
 		}
 
@@ -71,8 +70,8 @@ monitor DeviceResourceMonitor {
 		stream<integer> windowTotalMemUsageCounts := from measurement in memMeasurementStream within FIVE_MINS_INTERVAL select count();
 
 		from highUsageCount in windowHighMemUsageCounts from totalCount in windowTotalMemUsageCounts select 100.0 * highUsageCount.toFloat()/totalCount.toFloat() as lastFiveMinHighUsgaePercentage {
-			if (lastFiveMinHighUsgaePercentage >= MEM_PERCENTILE_THRESHOLD and lastMemReportTime + FIVE_MINS_INTERVAL <= currentTime) {
-				reportMemoryUsage(lastFiveMinHighUsgaePercentage);
+			if (lastFiveMinHighUsgaePercentage >= MEM_PERCENTILE_THRESHOLD and lastReportTime + FIVE_MINS_INTERVAL <= currentTime) {
+				sendReport(highCpuTimeFraction * 100.0, lastFiveMinHighUsgaePercentage);
 			}
 		}
 
@@ -87,45 +86,34 @@ monitor DeviceResourceMonitor {
 
 	}
 
-	action reportCpuUsage(float averageCpuUsage) {
-		float reportingTime := currentTime;
-		send RawCpuMeasurement(reportingTime.toString() + ":" + averageCpuUsage.toString()) to MQTT_SEND_CHANNEL;
-
-		// reset the cpu variables
-		cpuReadings := 0;
-		highCpuTimeFraction := 0.0;
-		lastCpuReportTime := reportingTime;
-
-		// schedule the next report
-		nextCpuReportWait := scheduleNextHourlyReport(nextCpuReportWait, paperReportCpuUsage);
-	}
-
-	action paperReportCpuUsage() {
-		reportCpuUsage(highCpuTimeFraction * 100.0);
-	}
-
-	action reportMemoryUsage(float averageMemUsage) {
-		float reportingTime := currentTime;
-		send RawMemMeasurement(reportingTime.toString() + ":" + averageMemUsage.toString()) to MQTT_SEND_CHANNEL;
-
-		// reset the mem variables
+	action resetVariables() {
 		memReadings := 0;
 		highMemTimeFraction := 0.0;
-		lastMemReportTime := reportingTime;
+
+		cpuReadings := 0;
+		highCpuTimeFraction := 0.0;
+	}
+
+	action sendReport(float highCpuTimePercent, float highMemTimePercent) {
+		float reportingTime := currentTime;
+
+		send ResourceUsageReport(TimeFormat.format(reportingTime, "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"), highCpuTimePercent, highMemTimePercent) to MQTT_SEND_CHANNEL;
+		lastReportTime := reportingTime;
+
+		resetVariables();
 
 		// schedule the next paper report
-		nextMemReportWait := scheduleNextHourlyReport(nextMemReportWait, paperReportMemoryUsage);
+		scheduleNextHourlyReport();
 	}
 
-	action paperReportMemoryUsage() {
-		reportMemoryUsage(highMemTimeFraction * 100.0);
+	action sendPaperReport() {
+		sendReport(highCpuTimeFraction * 100.0 , highMemTimeFraction * 100.0);
 	}
 
-	action scheduleNextHourlyReport(listener currentWaitListener, action<> reportUsageAction) returns listener {
-		currentWaitListener.quit();
-		listener newWaitListener := on wait(ONE_HOUR_INTERVAL) {
-			reportUsageAction();
+	action scheduleNextHourlyReport() {
+		nextReportTimer.quit();
+		nextReportTimer := on wait(ONE_HOUR_INTERVAL) {
+			sendPaperReport();
 		}
-		return newWaitListener;
 	}
 }

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
@@ -1,0 +1,13 @@
+event StatusUpdate {
+	string readTime;
+	float cpuPercent;
+	float memPercent;	
+}
+
+
+/** This monitor is responsible for ...  */
+monitor DeviceResourceMonitor {
+	action onload() {
+		log "Loaded monitor DeviceResourceMonitor" at INFO;		
+	}
+}

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
@@ -1,10 +1,9 @@
-using com.apama.aggregates.percentile;
 using com.apama.aggregates.count;
 
 /**
- *  This monitor is responsible for process the cpu and memory usage measurments received over a certain period
- *  of time. It reports the percentage of the that time period over which usage was above THRESHOLDs values.
- *  It reports to the cloud if the last five minutes high usage percentage is more than PERCENTILE_THRESHOLD.
+ *  This monitor is responsible for processing the cpu and memory usage measurments received over a certain period
+ *  of time. It reports the percentage of that time period for which a particular usage was above THRESHOLD value.
+ *  It reports to the cloud in FIVE_MINS_INTERVALs if the last five minutes high usage percentage is above PERCENTILE_THRESHOLD.
  *  otherwise it does an hourly paper report.
  */
 monitor DeviceResourceMonitor {
@@ -12,8 +11,8 @@ monitor DeviceResourceMonitor {
 	constant string MQTT_SEND_CHANNEL := "out";
 	constant string PROCESSED_MEASUREMENTS_CHANNEL := "PROCESSED_MEASUREMENTS_CHANNEL";
 
-	constant float ONE_HOUR_INTERVAL := 30.0;
-	constant float FIVE_MINS_INTERVAL := 5.0;
+	constant float ONE_HOUR_INTERVAL := 3600.0;
+	constant float FIVE_MINS_INTERVAL := 300.0;
 
 	constant float CPU_THRESHOLD := 70.0;
 	constant float MEM_THRESHOLD := 70.0;
@@ -42,13 +41,12 @@ monitor DeviceResourceMonitor {
 		// stream of cpu measurements
 		stream<CpuMeasurement> cpuMeasurementStream := all CpuMeasurement();
 
-		// derived streams of total cpu measurment counts and counts of measurements more than CPU_THRESHOLD within last FIVE_MINS_INTERVAL
+		// derived streams of total cpu measuerment counts and counts of measurements above CPU_THRESHOLD within last FIVE_MINS_INTERVAL
 		stream<integer> windowTotalCpuUsageCounts := from measurement in cpuMeasurementStream within FIVE_MINS_INTERVAL select count();
-		stream<integer> windowHighCpuUsageCounts := from measurement in cpuMeasurementStream within FIVE_MINS_INTERVAL select count(measurement.cpuMeasurement >= CPU_THRESHOLD);
+		stream<integer> windowHighCpuUsageCounts := from measurement in cpuMeasurementStream within FIVE_MINS_INTERVAL select count(measurement.percentActive >= CPU_THRESHOLD);
 
-		// calculate the time percentage for which cpu usage was above CPU_THRESHOLD
-		// report lastFiveMinHighUsgaePercentage if it has breached CPU_PERCENTILE_THRESHOLD
-		// and we have not reported in the last FIVE_MINS_INTERVAL
+		// calculate the time percentage for which cpu usage was above CPU_THRESHOLD within FIVE_MINS_INTERVAL
+		// report lastFiveMinHighUsgaePercentage if it has breached CPU_PERCENTILE_THRESHOLD and it has been five mins since last report
 		from highUsageCount in windowHighCpuUsageCounts from totalCount in windowTotalCpuUsageCounts select 100.0 * highUsageCount.toFloat()/totalCount.toFloat() as lastFiveMinHighUsgaePercentage {
 			if (lastFiveMinHighUsgaePercentage >= CPU_PERCENTILE_THRESHOLD and lastCpuReportTime + FIVE_MINS_INTERVAL <= currentTime) {
 				reportCpuUsage(lastFiveMinHighUsgaePercentage);
@@ -56,7 +54,7 @@ monitor DeviceResourceMonitor {
 		}
 
 		// maintain an overall time fraction of high usage since the last report in case it is going to be an hourly paper report
-		from cpuMeasurement in cpuMeasurementStream select cpuMeasurement.cpuMeasurement as measurement {
+		from cpuMeasurement in cpuMeasurementStream select cpuMeasurement.percentActive as measurement {
 			// calculate the cumulative percentile of the readings received since the last cpu usage report to the cloud
 			integer newReading := 0;
 			if measurement >= CPU_THRESHOLD {
@@ -69,7 +67,7 @@ monitor DeviceResourceMonitor {
 		// set up the same for memory usage measurements
 		stream<MemMeasurement> memMeasurementStream := all MemMeasurement();
 
-		stream<integer> windowHighMemUsageCounts := from measurement in memMeasurementStream within FIVE_MINS_INTERVAL select count(measurement.memMeasurement >= MEM_THRESHOLD);
+		stream<integer> windowHighMemUsageCounts := from measurement in memMeasurementStream within FIVE_MINS_INTERVAL select count(measurement.percentUsed >= MEM_THRESHOLD);
 		stream<integer> windowTotalMemUsageCounts := from measurement in memMeasurementStream within FIVE_MINS_INTERVAL select count();
 
 		from highUsageCount in windowHighMemUsageCounts from totalCount in windowTotalMemUsageCounts select 100.0 * highUsageCount.toFloat()/totalCount.toFloat() as lastFiveMinHighUsgaePercentage {
@@ -78,7 +76,7 @@ monitor DeviceResourceMonitor {
 			}
 		}
 
-		from memMeasurement in memMeasurementStream select memMeasurement.memMeasurement as measurement {
+		from memMeasurement in memMeasurementStream select memMeasurement.percentUsed as measurement {
 			integer newReading := 0;
 			if measurement >= MEM_THRESHOLD {
 				newReading := 1;

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/DeviceResourceMonitor.mon
@@ -1,28 +1,33 @@
-using com.apama.aggregates.mean;
+using com.apama.aggregates.percentile;
+using com.apama.aggregates.count;
 
 /**
- *  This monitor is responsible for process and aggregate the cpu and memory usage measurments received over a
- *  certain period of time. If reports the average values to the cloud for cpu/memory usage in an interval of 
- *  five minutes if the average breaches THRESHOLD values, otherwise it does an hourly paper report.
+ *  This monitor is responsible for process the cpu and memory usage measurments received over a certain period
+ *  of time. It reports the percentage of the that time period over which usage was above THRESHOLDs values.
+ *  It reports to the cloud if the last five minutes high usage percentage is more than PERCENTILE_THRESHOLD.
+ *  otherwise it does an hourly paper report.
  */
 monitor DeviceResourceMonitor {
 
 	constant string MQTT_SEND_CHANNEL := "out";
 	constant string PROCESSED_MEASUREMENTS_CHANNEL := "PROCESSED_MEASUREMENTS_CHANNEL";
 
-	constant float ONE_HOUR_INTERVAL := 120.0;
-	constant float FIVE_MINS_INTERVAL := 10.0;
+	constant float ONE_HOUR_INTERVAL := 30.0;
+	constant float FIVE_MINS_INTERVAL := 5.0;
 
-	constant float CPU_AVERAGE_THRESHOLD := 70.0;
-	constant float MEM_AVERAGE_THRESHOLD := 70.0;
+	constant float CPU_THRESHOLD := 70.0;
+	constant float MEM_THRESHOLD := 70.0;
+
+	constant float CPU_PERCENTILE_THRESHOLD := 70.0;
+	constant float MEM_PERCENTILE_THRESHOLD := 70.0;
 
 	integer cpuReadings := 0;
-	float cpuPercentCMA := 0.0;
+	float highCpuTimeFraction := 0.0;
 	float lastCpuReportTime := 0.0;
 	listener nextCpuReportWait;
 
 	integer memReadings := 0;
-	float memPercentCMA := 0.0;
+	float highMemTimeFraction := 0.0;
 	float lastMemReportTime := 0.0;
 	listener nextMemReportWait;
 
@@ -37,32 +42,48 @@ monitor DeviceResourceMonitor {
 		// stream of cpu measurements
 		stream<CpuMeasurement> cpuMeasurementStream := all CpuMeasurement();
 
-		// report lastFiveMinAverage of cpu measurements if it has breached CPU_AVERAGE_THRESHOLD
+		// derived streams of total cpu measurment counts and counts of measurements more than CPU_THRESHOLD within last FIVE_MINS_INTERVAL
+		stream<integer> windowTotalCpuUsageCounts := from measurement in cpuMeasurementStream within FIVE_MINS_INTERVAL select count();
+		stream<integer> windowHighCpuUsageCounts := from measurement in cpuMeasurementStream within FIVE_MINS_INTERVAL select count(measurement.cpuMeasurement >= CPU_THRESHOLD);
+
+		// calculate the time percentage for which cpu usage was above CPU_THRESHOLD
+		// report lastFiveMinHighUsgaePercentage if it has breached CPU_PERCENTILE_THRESHOLD
 		// and we have not reported in the last FIVE_MINS_INTERVAL
-		from cpuMeasurement in cpuMeasurementStream within FIVE_MINS_INTERVAL select mean(cpuMeasurement.cpuMeasurement) as lastFiveMinAverage {
-			if (lastFiveMinAverage >= CPU_AVERAGE_THRESHOLD and lastCpuReportTime + FIVE_MINS_INTERVAL <= currentTime) {
-				reportCpuUsage(lastFiveMinAverage);
+		from highUsageCount in windowHighCpuUsageCounts from totalCount in windowTotalCpuUsageCounts select 100.0 * highUsageCount.toFloat()/totalCount.toFloat() as lastFiveMinHighUsgaePercentage {
+			if (lastFiveMinHighUsgaePercentage >= CPU_PERCENTILE_THRESHOLD and lastCpuReportTime + FIVE_MINS_INTERVAL <= currentTime) {
+				reportCpuUsage(lastFiveMinHighUsgaePercentage);
 			}
 		}
 
-		// maintain an overall average in case it is going to be an hourly paper report
+		// maintain an overall time fraction of high usage since the last report in case it is going to be an hourly paper report
 		from cpuMeasurement in cpuMeasurementStream select cpuMeasurement.cpuMeasurement as measurement {
-			// calculate the cumulative average of the readings received since the last cpu usage report to the cloud
-			cpuPercentCMA := cpuPercentCMA + (measurement - cpuPercentCMA)/(cpuReadings + 1).toFloat();
+			// calculate the cumulative percentile of the readings received since the last cpu usage report to the cloud
+			integer newReading := 0;
+			if measurement >= CPU_THRESHOLD {
+				newReading := 1;
+			}
+			highCpuTimeFraction := highCpuTimeFraction + (newReading.toFloat() - highCpuTimeFraction)/(cpuReadings + 1).toFloat();
 			cpuReadings := cpuReadings + 1;
 		}
 
 		// set up the same for memory usage measurements
 		stream<MemMeasurement> memMeasurementStream := all MemMeasurement();
 
-		from memMeasurement in memMeasurementStream within FIVE_MINS_INTERVAL select mean(memMeasurement.memMeasurement) as lastFiveMinAverage {
-				if (lastFiveMinAverage >= MEM_AVERAGE_THRESHOLD and lastMemReportTime + FIVE_MINS_INTERVAL <= currentTime) {
-					reportMemoryUsage(lastFiveMinAverage);
-				}
+		stream<integer> windowHighMemUsageCounts := from measurement in memMeasurementStream within FIVE_MINS_INTERVAL select count(measurement.memMeasurement >= MEM_THRESHOLD);
+		stream<integer> windowTotalMemUsageCounts := from measurement in memMeasurementStream within FIVE_MINS_INTERVAL select count();
+
+		from highUsageCount in windowHighMemUsageCounts from totalCount in windowTotalMemUsageCounts select 100.0 * highUsageCount.toFloat()/totalCount.toFloat() as lastFiveMinHighUsgaePercentage {
+			if (lastFiveMinHighUsgaePercentage >= MEM_PERCENTILE_THRESHOLD and lastMemReportTime + FIVE_MINS_INTERVAL <= currentTime) {
+				reportMemoryUsage(lastFiveMinHighUsgaePercentage);
 			}
+		}
 
 		from memMeasurement in memMeasurementStream select memMeasurement.memMeasurement as measurement {
-			memPercentCMA := memPercentCMA + (measurement - memPercentCMA)/(memReadings + 1).toFloat();
+			integer newReading := 0;
+			if measurement >= MEM_THRESHOLD {
+				newReading := 1;
+			}
+			highMemTimeFraction := highMemTimeFraction + (newReading.toFloat() - highMemTimeFraction)/(memReadings + 1).toFloat();
 			memReadings := memReadings + 1;
 		}
 
@@ -74,7 +95,7 @@ monitor DeviceResourceMonitor {
 
 		// reset the cpu variables
 		cpuReadings := 0;
-		cpuPercentCMA := 0.0;
+		highCpuTimeFraction := 0.0;
 		lastCpuReportTime := reportingTime;
 
 		// schedule the next report
@@ -82,7 +103,7 @@ monitor DeviceResourceMonitor {
 	}
 
 	action paperReportCpuUsage() {
-		reportCpuUsage(memPercentCMA);
+		reportCpuUsage(highCpuTimeFraction * 100.0);
 	}
 
 	action reportMemoryUsage(float averageMemUsage) {
@@ -91,7 +112,7 @@ monitor DeviceResourceMonitor {
 
 		// reset the mem variables
 		memReadings := 0;
-		memPercentCMA := 0.0;
+		highMemTimeFraction := 0.0;
 		lastMemReportTime := reportingTime;
 
 		// schedule the next paper report
@@ -99,7 +120,7 @@ monitor DeviceResourceMonitor {
 	}
 
 	action paperReportMemoryUsage() {
-		reportMemoryUsage(memPercentCMA);
+		reportMemoryUsage(highMemTimeFraction * 100.0);
 	}
 
 	action scheduleNextHourlyReport(listener currentWaitListener, action<> reportUsageAction) returns listener {

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/PreprocessorUtil.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/PreprocessorUtil.mon
@@ -6,8 +6,8 @@
  */
 monitor PreprocessorUtil {
 
-	constant string MQTT_CPU_SUBSCRIBE_CHANNEL := "mqtt:cpu/percent-active";
-	constant string MQTT_MEM_SUBSCRIBE_CHANNEL := "mqtt:mem/percent-used";
+	constant string MQTT_CPU_SUBSCRIBE_CHANNEL := "mqtt:collectd/thin-edge/cpu/percent-active";
+	constant string MQTT_MEM_SUBSCRIBE_CHANNEL := "mqtt:collectd/thin-edge/mem/percent-used";
 	constant string PROCESSED_MEASUREMENTS_CHANNEL := "PROCESSED_MEASUREMENTS_CHANNEL";
 
 	action onload() {
@@ -18,7 +18,7 @@ monitor PreprocessorUtil {
 	action preprocessIncomingData() {
 		monitor.subscribe(MQTT_CPU_SUBSCRIBE_CHANNEL);
 		monitor.subscribe(MQTT_MEM_SUBSCRIBE_CHANNEL);
-		monitor.subscribe("in");
+
 		on all RawCpuMeasurement() as measurement {
 			send CpuMeasurement(preprocessMessage(measurement.cpuMeasurement)) to PROCESSED_MEASUREMENTS_CHANNEL;
 		}

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/PreprocessorUtil.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/PreprocessorUtil.mon
@@ -1,0 +1,32 @@
+
+/** This monitor is responsible for ...  */
+monitor PreprocessorUtil {
+
+	constant string MQTT_CPU_SUBSCRIBE_CHANNEL := "mqtt:cpu/percent-active";
+	constant string MQTT_MEM_SUBSCRIBE_CHANNEL := "mqtt:mem/percent-used";
+
+	action onload() {
+		log "Loaded monitor PreprocessorUtil" at INFO;
+		spawn preprocessIncomingData() to context("new_context");
+
+	}
+
+	action preprocessIncomingData() {
+		monitor.subscribe(MQTT_CPU_SUBSCRIBE_CHANNEL);
+		monitor.subscribe(MQTT_MEM_SUBSCRIBE_CHANNEL);
+		monitor.subscribe("in");
+
+		on all RawCpuMeasurement() as measurement {
+			send CpuMeasurement(preprocessMessage(measurement.cpuMeasurement)) to "PROCESSED_MEASUREMENTS_CHANNEL";
+		}
+
+		on all RawMemMeasurement() as measurement {
+			send MemMeasurement(preprocessMessage(measurement.memMeasurement)) to "PROCESSED_MEASUREMENTS_CHANNEL";
+		}
+	}
+
+	action preprocessMessage(string rawMeasurement) returns float {
+		integer startIndex := rawMeasurement.find(":") + 1;
+		return rawMeasurement.substring(startIndex, rawMeasurement.length()).toFloat();
+	}
+}

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/PreprocessorUtil.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/PreprocessorUtil.mon
@@ -1,27 +1,30 @@
 
-/** This monitor is responsible for ...  */
+/**
+ *  This monitor is responsible for preprocessing the raw measurements received over mqtt
+ *  and sending out the float values to the measurement processing code.
+ *  "<timestamp>:<measurement>" -----(preprocess)-----> <measurement>
+ */
 monitor PreprocessorUtil {
 
 	constant string MQTT_CPU_SUBSCRIBE_CHANNEL := "mqtt:cpu/percent-active";
 	constant string MQTT_MEM_SUBSCRIBE_CHANNEL := "mqtt:mem/percent-used";
+	constant string PROCESSED_MEASUREMENTS_CHANNEL := "PROCESSED_MEASUREMENTS_CHANNEL";
 
 	action onload() {
 		log "Loaded monitor PreprocessorUtil" at INFO;
 		spawn preprocessIncomingData() to context("new_context");
-
 	}
 
 	action preprocessIncomingData() {
 		monitor.subscribe(MQTT_CPU_SUBSCRIBE_CHANNEL);
 		monitor.subscribe(MQTT_MEM_SUBSCRIBE_CHANNEL);
-		monitor.subscribe("in");
 
 		on all RawCpuMeasurement() as measurement {
-			send CpuMeasurement(preprocessMessage(measurement.cpuMeasurement)) to "PROCESSED_MEASUREMENTS_CHANNEL";
+			send CpuMeasurement(preprocessMessage(measurement.cpuMeasurement)) to PROCESSED_MEASUREMENTS_CHANNEL;
 		}
 
 		on all RawMemMeasurement() as measurement {
-			send MemMeasurement(preprocessMessage(measurement.memMeasurement)) to "PROCESSED_MEASUREMENTS_CHANNEL";
+			send MemMeasurement(preprocessMessage(measurement.memMeasurement)) to PROCESSED_MEASUREMENTS_CHANNEL;
 		}
 	}
 

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/PreprocessorUtil.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/PreprocessorUtil.mon
@@ -18,7 +18,7 @@ monitor PreprocessorUtil {
 	action preprocessIncomingData() {
 		monitor.subscribe(MQTT_CPU_SUBSCRIBE_CHANNEL);
 		monitor.subscribe(MQTT_MEM_SUBSCRIBE_CHANNEL);
-
+		monitor.subscribe("in");
 		on all RawCpuMeasurement() as measurement {
 			send CpuMeasurement(preprocessMessage(measurement.cpuMeasurement)) to PROCESSED_MEASUREMENTS_CHANNEL;
 		}

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/Testing.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/Testing.mon
@@ -5,7 +5,7 @@ monitor Testing {
 		spawn testCode();
 	}
 	
-	float counter := 1.0;
+	float counter := 65.0;
 	
 	action testCode() {
 		monitor.subscribe("out");

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/Testing.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/Testing.mon
@@ -9,13 +9,18 @@ monitor Testing {
 	
 	action testCode() {
 		monitor.subscribe("out");
-		on all StatusReport() as status {
-			log "Got report at " + status.reportTime.toString() + " : CPU = " + status.cpuPercent.toString() + " , MEM: " + status.memPercent.toString() + " for duration "
-			+ status.monitoringDuration.toString();
+		on all RawCpuMeasurement() as cpu {
+			log "cpu for you " + cpu.toString();
 		}
-		
+
+		on all RawMemMeasurement() as mem {
+			log "mem for you " + mem.toString();
+		}
+
 		on all Trigger() {
-			send StatusUpdate(currentTime, counter, 30.0) to "in";
+			float timestamp := currentTime;
+			send RawCpuMeasurement(timestamp.toString() + ":" + counter.toString()) to "in";
+			send RawMemMeasurement(timestamp.toString() + ":" + "30.0") to "in";
 			counter := counter + 1.0;
 			on wait(1.0) {
 				send Trigger() to context.current();

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/Testing.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/Testing.mon
@@ -1,0 +1,27 @@
+monitor Testing {
+	
+	event Trigger {}
+	action onload() {
+		spawn testCode();
+	}
+	
+	float counter := 1.0;
+	
+	action testCode() {
+		monitor.subscribe("out");
+		on all StatusReport() as status {
+			log "Got report at " + status.reportTime.toString() + " : CPU = " + status.cpuPercent.toString() + " , MEM: " + status.memPercent.toString() + " for duration "
+			+ status.monitoringDuration.toString();
+		}
+		
+		on all Trigger() {
+			send StatusUpdate(currentTime, counter, 30.0) to "in";
+			counter := counter + 1.0;
+			on wait(1.0) {
+				send Trigger() to context.current();
+			}
+		}
+		route Trigger();
+		
+	}
+}

--- a/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/Testing.mon
+++ b/StreamingAnalytics/ResourceMonitoring/ResourceMonitoring/monitors/Testing.mon
@@ -19,8 +19,8 @@ monitor Testing {
 
 		on all Trigger() {
 			float timestamp := currentTime;
-			send RawCpuMeasurement(timestamp.toString() + ":" + counter.toString()) to "in";
-			send RawMemMeasurement(timestamp.toString() + ":" + "30.0") to "in";
+			send RawCpuMeasurement(timestamp.toString() + ":" + counter.toString()) to "mqtt:collectd/thin-edge/cpu/percent-active";
+			send RawMemMeasurement(timestamp.toString() + ":" + "30.0") to "collectd/thin-edge/mem/percent-used";
 			counter := counter + 1.0;
 			on wait(1.0) {
 				send Trigger() to context.current();

--- a/StreamingAnalytics/ResourceMonitoring/resource-monitor.py
+++ b/StreamingAnalytics/ResourceMonitoring/resource-monitor.py
@@ -1,0 +1,28 @@
+import psutil
+import paho.mqtt.client as mqtt
+import time
+
+mqttClient = mqtt.Client("Resource-monitor")
+broker = "localhost"
+
+def on_publish(client,userdata,result):             #create function for callback
+	print("data published \n")
+	pass
+
+def on_connect(client, userdate, flags, rc):
+	print("Connected to mosquitto with result {0}".format(rc))
+
+mqttClient.on_connect = on_connect
+mqttClient.on_publish = on_publish
+mqttClient.connect(broker)
+
+while True:
+	cpuPercent = psutil.cpu_percent()
+	memPercent = psutil.virtual_memory().percent
+	T = f'{time.time():.3f}'
+	
+	mqttClient.publish('collectd/thin-edge/cpu/percent-active', T + ":" + str(cpuPercent))
+	mqttClient.publish('collectd/thin-edge/mem/percent-used', T + ":" + str(memPercent))
+	time.sleep(5)
+
+


### PR DESCRIPTION
## Proposed changes

EPL sample to monitor CPU usage and calculate what percentage of the time the usage is over 70%. It reports it to the cloud in 5 mins cycle if this percentage is over 70% or once per hour if it is under 70%. 
Note that we are not reporting what is the average cpu usage but the percentage of time for which cpu breached the threshold. 
The same set of requirements were implemented for memory usage as well. 
**Incoming data**
The sample expect the incoming data to be available over mqtt in the following format: 
> <unix-timestamp>.<milli-seconds>:<value>
The same format is expected for cpu and memory measurements. These measurement differ in the subscribed topic 
-  MQTT_CPU_SUBSCRIBE_CHANNEL := "mqtt:collectd/thin-edge/cpu/percent-active"
- MQTT_MEM_SUBSCRIBE_CHANNEL := "mqtt:collectd/thin-edge/mem/percent-used"
## Outgoing data
The sample publishes a single json report to the cloud comprising of cpu and memory data. Here is a sample report: 
> {"memory":{"percent-used":30.0},"time":"2021-12-03T08:33:15.200+05:30","cpu":{"percent-active":45.0}}
The frequency is decided based on whether the time percentage over last 5 mins where the thresholds were breached for either of the resources was above 70% or not.
Note: The 'percent-used' and 'percent-active' are cpu or memory averages over the reporting period but the time percentage for which the usage breached the threshold values. I have used the names provided in the story. Maybe we can use some better name 

