### PR TITLE
remove reference to pidfile - doesn't work in thin-edge.io

### DIFF
--- a/StreamingAnalytics/LowLatencyCommandAndControl/project/arguments.yaml
+++ b/StreamingAnalytics/LowLatencyCommandAndControl/project/arguments.yaml
@@ -3,7 +3,6 @@
 server:
    port: ${correlator.port}
    name: ${correlator.name}
-   pidFile: ${correlator.pidFile}
 
 jvmOptions: [  ]
 correlator:

--- a/StreamingAnalytics/LowLatencyCommandAndControl/project/correlator.properties
+++ b/StreamingAnalytics/LowLatencyCommandAndControl/project/correlator.properties
@@ -15,5 +15,4 @@ correlator.javaApplicationSupport=false
 correlator.inputLogFile=${PARENT_DIR}/logs/defaultCorrelator_${$}{START_TIME}_${$}{ID}.input.log
 correlator.JVMHeapMb=512
 correlator.JVMOffheapStorageMb=16384
-correlator.pidFile=${correlator.logsDir}/${correlator.name}.pidfile
 correlator.extraArgs=

--- a/StreamingAnalytics/ResourceMonitoring/project/arguments.yaml
+++ b/StreamingAnalytics/ResourceMonitoring/project/arguments.yaml
@@ -3,7 +3,6 @@
 server:
    port: ${correlator.port}
    name: ${correlator.name}
-   pidFile: ${correlator.pidFile}
 
 jvmOptions: [  ]
 correlator:

--- a/StreamingAnalytics/ResourceMonitoring/project/correlator.properties
+++ b/StreamingAnalytics/ResourceMonitoring/project/correlator.properties
@@ -15,5 +15,4 @@ correlator.javaApplicationSupport=false
 correlator.inputLogFile=${PARENT_DIR}/logs/defaultCorrelator_${$}{START_TIME}_${$}{ID}.input.log
 correlator.JVMHeapMb=512
 correlator.JVMOffheapStorageMb=16384
-correlator.pidFile=${correlator.logsDir}/${correlator.name}.pidfile
 correlator.extraArgs=

--- a/StreamingAnalytics/src/quickstart/project/arguments.yaml
+++ b/StreamingAnalytics/src/quickstart/project/arguments.yaml
@@ -3,7 +3,6 @@
 server:
    port: ${correlator.port}
    name: ${correlator.name}
-   pidFile: ${correlator.pidFile}
 
 jvmOptions: [  ]
 correlator:

--- a/StreamingAnalytics/src/quickstart/project/correlator.properties
+++ b/StreamingAnalytics/src/quickstart/project/correlator.properties
@@ -15,5 +15,4 @@ correlator.javaApplicationSupport=false
 correlator.inputLogFile=${PARENT_DIR}/logs/defaultCorrelator_${$}{START_TIME}_${$}{ID}.input.log
 correlator.JVMHeapMb=512
 correlator.JVMOffheapStorageMb=16384
-correlator.pidFile=${correlator.logsDir}/${correlator.name}.pidfile
 correlator.extraArgs=


### PR DESCRIPTION
The underlying bug will be fixed separately, but for now this workaround at least makes this sample work out of the box