### PR TITLE
add new opcua example which uses thin-edge.io on host

### DIFF
--- a/opcua-docker/README.md
+++ b/opcua-docker/README.md
@@ -11,14 +11,21 @@ This guide shows how to use the `thin-edge/opcua-device-gateway` container to ru
 
 ## Getting started
 
-1. Create a folder on your device called `opcua`
+1. Enable the mqtt listener to accept connections other than from 127.0.0.1
+
+    ```sh
+    tedge config set mqtt.bind.address 0.0.0.0
+    tedge refresh-bridges
+    ```
+
+2. Create a folder on your device called `opcua`
 
     ```sh
     mkdir opcua
     cd opcua
     ```
 
-2. Create the docker compose file and copy the linked file contents to it
+3. Create the docker compose file and copy the linked file contents to it
 
     ```sh
     docker-compose.yaml
@@ -26,7 +33,7 @@ This guide shows how to use the `thin-edge/opcua-device-gateway` container to ru
 
     Copy the contents from this file: [docker-compose.yaml](./docker-compose.yml)
 
-3. Start the docker compose project
+4. Start the docker compose project
 
     ```sh
     docker compose up -d

--- a/opcua-docker/README.md
+++ b/opcua-docker/README.md
@@ -1,0 +1,78 @@
+# Using OPC UA Container with thin-edge.io natively
+
+This guide shows how to use the `thin-edge/opcua-device-gateway` container to run under docker whilst communicating with a thin-edge.io setup which is running natively on the Operation System.
+
+## Pre-requisites
+
+* **arm64** or **amd64** Linux Operating System
+* thin-edge.io installed on your host operating system and it is already connected to Cumulocity IoT
+* docker engine >=20.18
+* docker compose plugin
+
+## Getting started
+
+1. Create a folder on your device called `opcua`
+
+    ```sh
+    mkdir opcua
+    cd opcua
+    ```
+
+2. Create the docker compose file and copy the linked file contents to it
+
+    ```sh
+    docker-compose.yaml
+    ```
+
+    Copy the contents from this file: [docker-compose.yaml](./docker-compose.yml)
+
+3. Start the docker compose project
+
+    ```sh
+    docker compose up -d
+    ```
+    
+    You can view the logs using the following command:
+
+    ```sh
+    docker compose logs gateway -f
+    ```
+
+## Example public OPC UA Servers
+
+You can test the setup by connecting to a few public OPC UA servers, though be aware that these can be slow to respond, but it should at least give you and idea if your setup is working.
+
+### opcua.demo-this.com
+
+The node scan takes about 6-7 minutes.
+
+|Property|Value|
+|--|--|
+|server|opc.tcp://opcua.demo-this.com:51210/UA/SampleServer|
+|Security Mode|None|
+|Security Policy|None|
+|Authentication|Anonymous|
+
+
+### opcuaserver.com
+
+The node scan takes > 30 mins!
+
+|Property|Value|
+|--|--|
+|server|opc.tcp://opcuaserver.com:48010|
+|Security Mode|None|
+|Security Policy|None|
+|Authentication|Anonymous|
+
+
+## Known errors
+
+### java.lang.UnsatisfiedLinkError
+
+Currently the following warning occurs on some setups when the `gateway` service starts. The application continues after the warning is printed. It is currently unknown what the exact impact is.
+
+```log
+Caused by: java.lang.UnsatisfiedLinkError: could not get native definition for type `POINTER`, original error message follows: java.lang.UnsatisfiedLinkError: Unable to execute or load jffi binary stub from `/tmp`. Set `TMPDIR` or Java property `java.io.tmpdir` to a read/write path that is not mounted "noexec".
+/app/jffi12820354458810240894.so: Error loading shared library ld-linux-aarch64.so.1: No such file or directory (needed by /app/jffi12820354458810240894.so)
+```

--- a/opcua-docker/docker-compose.yml
+++ b/opcua-docker/docker-compose.yml
@@ -3,13 +3,9 @@ version: "3.2"
 services:
   gateway:
     # Image is maintained under: https://github.com/thin-edge/opcua-device-gateway-container
-    image: ghcr.io/thin-edge/opcua-device-gateway:20240106.0203
+    image: ghcr.io/thin-edge/opcua-device-gateway:20240206.0953
     restart: always
     environment:
-      # OPCUA Gateway info
-      - OPCUA_GATEWAY_IDENTIFIER=${OPCUA_GATEWAY_IDENTIFIER:-RpiOPCUAGateway001}
-      - OPCUA_GATEWAY_NAME=${OPCUA_GATEWAY_NAME:-RPI_OPCUA_GATEWAY_AGENT}
-
       # thin-edge.io MQTT broker
       - MQTT_BROKER=host.docker.internal:1883
       - DEVICE_ID=${DEVICE_ID:-}

--- a/opcua-docker/docker-compose.yml
+++ b/opcua-docker/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.2"
+
+services:
+  gateway:
+    # Image is maintained under: https://github.com/thin-edge/opcua-device-gateway-container
+    image: ghcr.io/thin-edge/opcua-device-gateway:20240106.0203
+    restart: always
+    environment:
+      # OPCUA Gateway info
+      - OPCUA_GATEWAY_IDENTIFIER=${OPCUA_GATEWAY_IDENTIFIER:-RpiOPCUAGateway001}
+      - OPCUA_GATEWAY_NAME=${OPCUA_GATEWAY_NAME:-RPI_OPCUA_GATEWAY_AGENT}
+
+      # thin-edge.io MQTT broker
+      - MQTT_BROKER=host.docker.internal:1883
+      - DEVICE_ID=${DEVICE_ID:-}
+      - C8Y_BASEURL=${C8Y_BASEURL:-}
+    volumes:
+      - opcua_data:/data
+      # Provide access to thin-edge.io configuration
+      - /etc/tedge:/etc/tedge
+      - /etc/tedge/device-certs:/etc/tedge/device-certs
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - backend
+
+volumes:
+  opcua_data:
+
+networks:
+  backend:


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adding new opcua example which runs the opcua gateway server in a container, but communicates with thin-edge.io running on the host (e.g. natively).

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New example (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
